### PR TITLE
Fix event priority for shifting the renderer back

### DIFF
--- a/src/main/java/com/rebelkeithy/dualhotbar/RenderHandler.java
+++ b/src/main/java/com/rebelkeithy/dualhotbar/RenderHandler.java
@@ -167,7 +167,7 @@ public class RenderHandler
     	}
     }
 
-	@SubscribeEvent(priority = EventPriority.HIGHEST)
+	@SubscribeEvent(priority = EventPriority.LOWEST)
     public void shiftRendererDown(RenderGameOverlayEvent.Post event)
     {
 		if(!DualHotbarConfig.enable || (!DualHotbarConfig.twoLayerRendering && DualHotbarConfig.numHotbars != 4))


### PR DESCRIPTION
- The shift should be the last RenderGameOverlayEvent.Post event fired, not the first RenderGameOverlayEvent.Post event fired
- Fixes incompatibility with AppleCore hunger overlay (see squeek502/AppleCore#30)
